### PR TITLE
Change to fix re-adding tile entities to ships

### DIFF
--- a/src/main/java/ckathode/archimedes/chunk/ChunkDisassembler.java
+++ b/src/main/java/ckathode/archimedes/chunk/ChunkDisassembler.java
@@ -9,6 +9,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 import ckathode.archimedes.ArchimedesShipMod;
 import ckathode.archimedes.blockitem.TileEntityHelm;
@@ -141,7 +142,11 @@ public class ChunkDisassembler
 						{
 							((IShipTileEntity) tileentity).setParentShip(null, i, j, k);
 						}
-						world.setTileEntity(ix, iy, iz, tileentity);
+                        NBTTagCompound comp = new NBTTagCompound();
+                        tileentity.writeToNBT(comp);
+                        TileEntity temp = new TileEntity();
+                        world.setTileEntity(ix, iy, iz, temp.createAndLoadEntity(comp));
+                        tileentity.readFromNBT(comp);
 						tileentity.blockMetadata = meta;
 					}
 					


### PR DESCRIPTION
This is a fix in response to my post on the forums: http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/1289952-archimedes-ships-v1-7-banking-ships?comment=3529

Tile entities were keeping some information after being re-added to ships during disassembly that was making them tick faster than they were supposed to. Re-building the tile entities from the NBT data instead of giving them the old tile entity seems to make it work as intended.
