### PR TITLE
Removed hack for tile entities, added proper fix

### DIFF
--- a/src/main/java/ckathode/archimedes/chunk/AssembleResult.java
+++ b/src/main/java/ckathode/archimedes/chunk/AssembleResult.java
@@ -121,11 +121,7 @@ public class AssembleResult
 				tileentity = lb.tileEntity;
 				if (tileentity != null || lb.block.hasTileEntity(lb.blockMeta) && (tileentity = world.getTileEntity(lb.coords.chunkPosX, lb.coords.chunkPosY, lb.coords.chunkPosZ)) != null)
 				{
-					world.removeTileEntity(lb.coords.chunkPosX, lb.coords.chunkPosY, lb.coords.chunkPosZ);
 					tileentity.validate();
-					tileentity.updateContainingBlockInfo();
-					tileentity.blockType = lb.block;
-					tileentity.blockMetadata = lb.blockMeta;
 				}
 				if (entity.getShipChunk().setBlockIDWithMetadata(ix, iy, iz, lb.block, lb.blockMeta))
 				{

--- a/src/main/java/ckathode/archimedes/chunk/ChunkDisassembler.java
+++ b/src/main/java/ckathode/archimedes/chunk/ChunkDisassembler.java
@@ -142,12 +142,8 @@ public class ChunkDisassembler
 						{
 							((IShipTileEntity) tileentity).setParentShip(null, i, j, k);
 						}
-                        NBTTagCompound comp = new NBTTagCompound();
-                        tileentity.writeToNBT(comp);
-                        TileEntity temp = new TileEntity();
-                        world.setTileEntity(ix, iy, iz, temp.createAndLoadEntity(comp));
-                        tileentity.readFromNBT(comp);
-						tileentity.blockMetadata = meta;
+						tileentity.validate();
+                        world.setTileEntity(ix, iy, iz, tileentity);
 					}
 					
 					if (!ArchimedesShipMod.instance.metaRotations.hasBlock(block))

--- a/src/main/java/ckathode/archimedes/chunk/MobileChunk.java
+++ b/src/main/java/ckathode/archimedes/chunk/MobileChunk.java
@@ -191,7 +191,6 @@ public class MobileChunk implements IBlockAccess
 			
 			if (tileentity == null)
 			{
-				tileentity = block.createTileEntity(worldObj, meta);
 				setTileEntity(x, y, z, tileentity);
 			}
 			
@@ -268,13 +267,7 @@ public class MobileChunk implements IBlockAccess
 	{
 		ChunkPosition chunkposition = new ChunkPosition(x, y, z);
 		TileEntity tileentity = chunkTileEntityMap.get(chunkposition);
-		
-		if (tileentity != null && tileentity.isInvalid())
-		{
-			chunkTileEntityMap.remove(chunkposition);
-			tileentity = null;
-		}
-		
+				
 		if (tileentity == null)
 		{
 			Block block = getBlock(x, y, z);
@@ -296,7 +289,7 @@ public class MobileChunk implements IBlockAccess
 	
 	public void setTileEntity(int x, int y, int z, TileEntity tileentity)
 	{
-		if (tileentity == null || tileentity.isInvalid())
+		if (tileentity == null)
 		{
 			return;
 		}
@@ -321,23 +314,13 @@ public class MobileChunk implements IBlockAccess
 		Block block = getBlock(x, y, z);
 		if (block != null && block.hasTileEntity(getBlockMetadata(x, y, z)))
 		{
-			if (chunkTileEntityMap.containsKey(chunkposition))
-			{
-				chunkTileEntityMap.get(chunkposition).invalidate();
-			}
-			
 			tileentity.blockMetadata = getBlockMetadata(x, y, z);
-			tileentity.validate();
+			tileentity.invalidate();
 			chunkTileEntityMap.put(chunkposition, tileentity);
 			
 			if (tileentity instanceof IShipTileEntity)
 			{
 				((IShipTileEntity) tileentity).setParentShip(entityShip, ox, oy, oz);
-			}
-			
-			if (isChunkLoaded)
-			{
-				worldObj.addTileEntity(tileentity);
 			}
 		}
 	}


### PR DESCRIPTION
Admittedly, rebuilding the tile entity from NBT data on ship disassemble was at best a messy solution. Some mods such as Applied Energistics do not allow editing their tile entities's NBT data outside of the methods implemented through their API, leading to errors/crashes on ship disassemble. Following advice from Algorithm2X, tile entities are now invalidated, moved, and re-validated instead, which address the problems with tile entities more thoroughly than my previously committed hack.

Some code was deleted from MobileChunks as in my testing it was found to either not be used, to be redundant or to cause mischief with the tile entities.
